### PR TITLE
fix: make multiple shells use the same overlay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,13 +273,14 @@ dependencies = [
 
 [[package]]
 name = "dive"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",
  "dirs",
  "env_logger",
  "exitcode",
+ "fd-lock",
  "image_builder",
  "indicatif",
  "liblzma",
@@ -349,6 +350,17 @@ name = "fastrand"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "filetime"
@@ -618,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "image_builder"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ serde_json = "1.0"
 tar = { workspace = true }
 tempfile = { workspace = true }
 which = "6.0.3"
+fd-lock = "4.0.2"
 
 [[bin]]
 name = "dive"

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -2,7 +2,7 @@ use std::fs::create_dir_all;
 use std::path::Path;
 use std::{os::fd::OwnedFd, path::PathBuf};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use rustix::fd::AsFd;
 use rustix::fs;
 use rustix::mount::{
@@ -20,7 +20,7 @@ impl OverlayMount {
     ) -> Result<Self> {
         let lower_dir = lower_dir.into().canonicalize()?;
         let fsfd = fsopen("overlay", FsOpenFlags::FSOPEN_CLOEXEC)?;
-        fsconfig_set_string(fsfd.as_fd(), "source", "nsdb")?;
+        fsconfig_set_string(fsfd.as_fd(), "source", "user-data")?;
         fsconfig_set_string(fsfd.as_fd(), "lowerdir", lower_dir)?;
         fsconfig_set_string(fsfd.as_fd(), "upperdir", upper_dir.as_ref())?;
         fsconfig_set_string(fsfd.as_fd(), "workdir", work_dir.as_ref())?;
@@ -48,5 +48,43 @@ impl OverlayMount {
             MoveMountFlags::MOVE_MOUNT_F_EMPTY_PATH,
         )?;
         Ok(())
+    }
+}
+
+pub struct OverlayBuilder {
+    pub lower_dir: PathBuf,
+    pub merged_dir: PathBuf,
+    pub upper_dir: PathBuf,
+    pub work_dir: PathBuf,
+    pub pids_dir: PathBuf,
+}
+
+impl OverlayBuilder {
+    pub fn new<P, Q>(base_dir: P, lower_dir: Q) -> Result<Self>
+    where
+        P: AsRef<Path>,
+        Q: AsRef<Path>,
+    {
+        let base_dir = base_dir.as_ref();
+        let lower_dir = lower_dir.as_ref().to_owned();
+
+        let merged_dir = base_dir.join("merged");
+        let upper_dir = base_dir.join("upper");
+        let work_dir = base_dir.join("work");
+        let pids_dir = base_dir.join("pids");
+
+        create_dir_all(&merged_dir)
+            .and(create_dir_all(&upper_dir))
+            .and(create_dir_all(&work_dir))
+            .and(create_dir_all(&pids_dir))
+            .context("could not create overlay directories")?;
+
+        Ok(OverlayBuilder {
+            lower_dir,
+            merged_dir,
+            upper_dir,
+            work_dir,
+            pids_dir,
+        })
     }
 }

--- a/src/pid_file.rs
+++ b/src/pid_file.rs
@@ -1,0 +1,29 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process,
+};
+
+use anyhow::Result;
+
+pub struct PidFile {
+    path: PathBuf,
+}
+
+impl PidFile {
+    pub fn new(dir: &Path) -> Result<Self> {
+        let pid = process::id().to_string();
+        let path = dir.join(&pid);
+        std::fs::write(&path, pid)?;
+        Ok(PidFile { path })
+    }
+}
+
+impl Drop for PidFile {
+    fn drop(&mut self) {
+        log::debug!("removing {}", self.path.display());
+        if let Err(err) = fs::remove_file(&self.path) {
+            log::error!("while removing: {}", err);
+        }
+    }
+}

--- a/src/pid_lookup.rs
+++ b/src/pid_lookup.rs
@@ -103,9 +103,12 @@ const _RUNTIMES: &[ContainerRuntime] = &[
     },
 ];
 
-pub(crate) fn pid_lookup(name: &str) -> Option<i32> {
+pub(crate) fn pid_lookup(value: &str) -> Option<i32> {
+    if let Ok(pid) = value.parse::<i32>() {
+        return Some(pid);
+    };
     return _RUNTIMES
         .iter()
         .filter(|r| (r.available)())
-        .find_map(|r| (r.get_pid)(name));
+        .find_map(|r| (r.get_pid)(value));
 }

--- a/src/shared_mount.rs
+++ b/src/shared_mount.rs
@@ -1,0 +1,140 @@
+use std::{
+    fs::{remove_file, File, OpenOptions},
+    os::fd::{AsFd, OwnedFd},
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result};
+use fd_lock::RwLock;
+use rustix::{
+    fs::MountPropagationFlags,
+    mount::{
+        mount_change, move_mount, open_tree, MoveMountFlags, OpenTreeFlags,
+    },
+    thread::{
+        move_into_thread_name_spaces, unshare, ThreadNameSpaceType,
+        UnshareFlags,
+    },
+};
+
+use crate::{pid_file::PidFile, OverlayBuilder, OverlayMount};
+
+pub struct SharedMount {
+    _pid_file: PidFile,
+    merged_dir: PathBuf,
+}
+
+impl SharedMount {
+    pub fn new(
+        base_dir: &Path,
+        overlay_builder: OverlayBuilder,
+    ) -> Result<Self> {
+        let mut flock = RwLock::new(
+            OpenOptions::new()
+                .append(true)
+                .create(true)
+                .open(base_dir.join("lock"))?,
+        );
+        let _guard = flock.write()?;
+
+        let mut ns_found = false;
+        let pids_dir = &overlay_builder.pids_dir;
+        let merged_dir = overlay_builder.merged_dir.clone();
+
+        for entry in pids_dir.read_dir().unwrap() {
+            let entry = entry?;
+            let pid = entry.file_name();
+            log::debug!("checking {:?}", pid);
+            match File::open(format!("/proc/{}/ns/mnt", pid.to_string_lossy()))
+            {
+                Err(err) => {
+                    log::debug!("pid file open: {}", err);
+                    let _ = remove_file(entry.path()).is_ok();
+                    continue;
+                }
+                Ok(f) => {
+                    if move_into_thread_name_spaces(
+                        f.as_fd(),
+                        ThreadNameSpaceType::MOUNT,
+                    )
+                    .is_ok()
+                    {
+                        log::debug!("entered mount namespace");
+                        ns_found = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if !ns_found {
+            log::debug!("enter new mount namespace");
+            unshare(UnshareFlags::NEWNS)
+                .context("could not create new mount namespace")?;
+
+            log::debug!("make mounts private");
+            mount_change(
+                "/",
+                MountPropagationFlags::PRIVATE | MountPropagationFlags::REC,
+            )?;
+
+            log::debug!("mount base in state dir");
+            OverlayMount::new(
+                overlay_builder.lower_dir,
+                overlay_builder.upper_dir,
+                overlay_builder.work_dir,
+            )
+            .and_then(|ovl| ovl.mount(&overlay_builder.merged_dir))
+            .context("could not mount base image")?;
+        }
+
+        let pid_file =
+            PidFile::new(pids_dir).context("failed to create pid file")?;
+
+        let mnt = SharedMount {
+            _pid_file: pid_file,
+            merged_dir,
+        };
+
+        Ok(mnt)
+    }
+
+    pub fn make_detached_mount(&self) -> Result<DetachedMount> {
+        let tree_fd = open_tree(
+            rustix::fs::CWD,
+            &self.merged_dir,
+            OpenTreeFlags::OPEN_TREE_CLONE | OpenTreeFlags::OPEN_TREE_CLOEXEC,
+        )?;
+
+        Ok(DetachedMount(tree_fd))
+    }
+}
+
+pub struct DetachedMount(OwnedFd);
+
+impl DetachedMount {
+    pub fn mount<P>(self, target: P) -> Result<()>
+    where
+        P: AsRef<Path>,
+    {
+        move_mount(
+            self.0.as_fd(),
+            "",
+            rustix::fs::CWD,
+            target.as_ref(),
+            MoveMountFlags::MOVE_MOUNT_F_EMPTY_PATH,
+        )?;
+
+        Ok(())
+    }
+
+    pub fn mount_in_new_namespace<P>(self, target: P) -> Result<()>
+    where
+        P: AsRef<Path>,
+    {
+        unshare(UnshareFlags::NEWNS)
+            .context("could not create new mount namespace")?;
+
+        self.mount(target)
+    }
+}


### PR DESCRIPTION
This avoids conflicts between the different overlays all using the same upper & work directories. Also, now changes in any shell are visible consistently everywhere.